### PR TITLE
Release version 0.1.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,12 @@ resolver = "2"
 bindgen = "0.68"
 cc = "1.0"
 glob = "0.3"
-kusabira = { path = "kusabira", version = "0.1" }
+himetake = "0.1"
+kusabira = "0.1"
 system-deps = "6.1"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Seigo Tanimura <seigo.tanimura@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/kusabira/src/builder.rs
+++ b/kusabira/src/builder.rs
@@ -907,8 +907,15 @@ impl<'a> Config<'a>
 	///
 	/// # Example
 	/// Below is the build script excerpt of
-	/// [`himetake`](../../himetake/index.html) version 0.1.0, modified
-	/// slightly for the better understanding:
+	/// `himetake`, modified slightly for the better understanding.
+	/// > The document of `himetake`, as of version 0.1.0, is not published on
+	/// > [`crates.io`](https://crates.io/) for an unknown reason.
+	/// >
+	/// > For the actual implementation, please download the
+	/// > [`Cargo`](https://doc.rust-lang.org/cargo/) workspace source from
+	/// > [the GitHub repository](https://github.com/altimeter-130ft/kusabira)
+	/// > and build the document by
+	/// > [`cargo doc`](https://doc.rust-lang.org/cargo/commands/cargo-doc.html).
 	/// ```no_run
 	/// use kusabira::builder::Config as MldBuilderConfig;
 	/// use kusabira::hooks::cc::warnings_into_errors;


### PR DESCRIPTION
Mention that the Rust document of himetake is not on crates.io somehow.

The dependencies on kusabira and himetake no longer need the paths.